### PR TITLE
Add PATCH merge support for partial updates

### DIFF
--- a/addon/serializer.js
+++ b/addon/serializer.js
@@ -46,6 +46,7 @@ export default DS.RESTSerializer.extend({
       this.serializeAttribute(record, json, key, attribute);
     }, this);
 
+    delete json.ref;
     delete json.timestamp;
     delete json.ordinal;
 
@@ -59,6 +60,7 @@ export default DS.RESTSerializer.extend({
     if (hash.path && hash.value) {
       json = hash.value;
       json.id = hash.path.key;
+      json.ref = hash.path.ref;
     }
 
     // event

--- a/tests/unit/models/biker-test.js
+++ b/tests/unit/models/biker-test.js
@@ -5,11 +5,15 @@ import {
 import Pretender from 'pretender';
 import Ember from 'ember';
 
+var store;
 var server;
 
 moduleForModel('biker', 'Biker model', {
   needs: ['model:bike', 'adapter:application', 'serializer:application'],
-  teardown: function(){
+  setup: function(container) {
+    container.lookup('adapter:application').set('usePatch', false);
+  },
+  teardown: function() {
     if (server) {
       server.shutdown();
       server = null;

--- a/tests/unit/models/patch-test.js
+++ b/tests/unit/models/patch-test.js
@@ -1,0 +1,54 @@
+import {
+  moduleForModel,
+  test
+} from 'ember-qunit';
+import Pretender from 'pretender';
+import Ember from 'ember';
+
+var server;
+
+moduleForModel('biker', 'Patch', {
+  needs: ['model:bike', 'adapter:application', 'serializer:application'],
+  teardown: function() {
+    if (server) {
+      server.shutdown();
+      server = null;
+    }
+  }
+});
+
+test('patches a record', function() {
+  server = new Pretender(function() {
+    this.patch('/orchestrate/v0/bikers/035ab997adffe604', function(request) {
+      var headers = request.requestHeaders;
+      var json = JSON.parse(request.requestBody);
+
+      equal(headers['If-Match'], '"82eafab14dc84ee4"', 'has correct if-match');
+      equal(headers['Content-Type'], 'application/merge-patch+json;charset=utf-8', 'has correct content-type');
+      deepEqual(json, { name: 'Steven' }, 'has correct JSON');
+      return [201, {
+        'location': '/v0/bikers/035ab997adffe604/refs/82eafab14dc84ed3'
+      }, {}];
+    });
+  });
+
+  var store = this.store();
+
+  return Ember.run(function() {
+    store.push('biker', {
+      id: '035ab997adffe604',
+      ref: '82eafab14dc84ee4',
+      name: 'Steve'
+    });
+
+    return store.find('biker', '035ab997adffe604').then(function(biker) {
+      biker.set('name', 'Steven');
+      return biker.save().then(function(biker) {
+        ok(biker, 'record updated');
+        ok(biker.get('id'), '035ab997adffe604', 'record loaded');
+        equal(biker.get('name'), 'Steven', 'record attribute was updated');
+        equal(biker.get('ref'), '82eafab14dc84ed3', 'record ref was updated');
+      });
+    });
+  });
+});


### PR DESCRIPTION
Updating a record will now send a patch-merge request with only changed attributes by default. PUT requests can still be used by setting the `usePatch` flag on the adapter to false.
